### PR TITLE
Smooth data and add signal flag

### DIFF
--- a/randomForest/randomForest.py
+++ b/randomForest/randomForest.py
@@ -65,9 +65,23 @@ def add_data():
     files = (p.glob('ticker_*.csv'))
     
     def relative_strength_index(df):
-    
         # Calculate the change in price
         delta = df['Close'].diff().dropna()
+        
+        # define the number of days out you want to predict
+        days_out = 30
+
+        # Calculate ema to give more weight to recent values while smoothing out fluctuation
+        price_data_smoothed = df[['Close', 'Low', 'High', 'Open', 'Volume']].ewm(span=days_out).mean()
+
+        # Join the smoothed columns with the symbol and datetime column
+        smoothed_df = pd.concat([df[['Symbol', 'Date']], price_data_smoothed], axis=1)
+        
+        # Calculate the flag, and calculate the diff compared to 30 days ago
+        smoothed_df['Signal_Flag'] = np.sign(df['Close'].diff(days_out))
+
+        # print the first 50 rows
+        print(smoothed_df.head(50))
         
         # Calculate momentum since we want to predict if the stock goes up and down, not the price itself
         # Momentum indicator Relative Strength Index
@@ -185,17 +199,11 @@ def add_data():
         df = pd.read_csv(file)
                
         relative_strength_index(df)
-    
         stochastic_oscillator(df)
-        
         williams_r(df)
-        
         macd(df)
-        
         price_rate_change(df)
-        
         obv(df)
-        
         direction_prediction(df)
         
         df.to_csv(file, index=False)

--- a/randomForest/simulation.py
+++ b/randomForest/simulation.py
@@ -40,10 +40,10 @@ p = Path('randomForest/csvDataFrames')
 files = p.glob('ticker_*.csv')
 
 # Input number of days to simulate
-days_to_simulate = 5 # Replace with days to simulate
+days_to_simulate = 100 # Replace with days to simulate
 
 # Initialize variables for global sum
-global_initial_money = 10000 # Replace with your initial investment amount
+global_initial_money = 1000 # Replace with your initial investment amount
 global_final_value = 0
 
 # Simulate trading for each stock


### PR DESCRIPTION
Close #3 
Close #4 

Smooth Data
Using pandas to smooth data so predictions 30 days out, 60 days out and 90 days out are possible. This removes the randomness and noise from the data frame.

Signal Flag
This will serve as diff column from the original data frame.  We desire the days we want to predict out rather than one consecutive day to the next. Use numpy.sign() and the smooth data window to calculate the smoothed statistic and predict the direction of the stock which will return a 1.0 if positive, -1.0 if negative and 0.0 if no change.